### PR TITLE
Prep for use as a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8-slim
+
+WORKDIR /home/node/ws-log
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+USER node
+EXPOSE 4277
+CMD ["bin/ws-log","/var/log/logfile"]
+

--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 const pkg = require('./package.json');
+const LINES = process.env.WS_LINES || 5;
 
 module.exports = require('yargs')
   .env('LOGVIEWER')
@@ -23,8 +24,14 @@ module.exports = require('yargs')
     v: 'version',
   })
   .default({
+    'user': process.env.WS_USER,
+    'password': process.env.WS_PASSWORD,
+    'ssl': process.env.WS_SSL,
+    'certfile': process.env.WS_CERTFILE,
+    'keyfile': process.env.WS_KEYFILE,
+    'filters': process.env.WS_FILTERS,
     'port': 4277,
-    'lines': 5,
+    'lines': LINES,
   })
   .version()
   .help('help')


### PR DESCRIPTION
Added a dockerfile that doesn't do much and expose the args as environment variables. Since it's running in docker I don't think port needs to be its own var but that could be changed. I added a `WS_` prefix because I didn't want something lengthy and didn't want to confuse any possible `$USER` already existing in the container.

Sample command for running the container:
```
docker run -d --name logs \
    -p 4277:4277 \
    -e WS_USER=test \
    -e WS_PASSWORD=test \
    -v ${HOME}/homeassistant/home-assistant.log:/var/log/logfile \
    93252e598188
```