### PR TITLE
🔨 Makes WebSocket URI relative to current URI

### DIFF
--- a/public/js/websocket.js
+++ b/public/js/websocket.js
@@ -4,7 +4,13 @@
   var reconnect = true;
   var ws;
 
-  var wsUrl = window.location.origin.replace(/^http/, 'ws');
+  var loc = window.location, wsUrl;
+  if (loc.protocol == "https:") {
+    wsUrl = "wss:";
+  } else {
+    wsUrl = "ws:";
+  }
+  wsUrl += "//" + loc.host + loc.pathname;
 
   function setStatus(status) {
     $('.status').html(status);


### PR DESCRIPTION
This allows reverse proxies with subfolders to work with the WebSocket.
Also, adds support or https/wss.

This change allows the Hass.io add-on to work with Ingress.